### PR TITLE
fix: hyper and axum benchmarks don't run

### DIFF
--- a/benchmark/hello-world/axum/src/main.rs
+++ b/benchmark/hello-world/axum/src/main.rs
@@ -5,5 +5,5 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     let app = Router::new().route("/", get(|| async { "Hello, World!" }));
 
-    let _ = axum::serve(listener, app);
+    let _ = axum::serve(listener, app).await;
 }

--- a/benchmark/hello-world/hyper/src/main.rs
+++ b/benchmark/hello-world/hyper/src/main.rs
@@ -6,7 +6,7 @@ use std::{convert::Infallible, net::SocketAddr};
 
 #[tokio::main]
 async fn main() {
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
     let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(hello_world)) });
 


### PR DESCRIPTION
they now run correctly with the command:

```bash
cargo run --release -- -w ../benchmark -o ../result
```